### PR TITLE
Update SelfStudyBoard, MassageBoard

### DIFF
--- a/src/api/massage.ts
+++ b/src/api/massage.ts
@@ -1,0 +1,33 @@
+import { toast } from 'react-toastify';
+import { apiClient } from 'utils/Libs/apiClient';
+import { MassageController } from 'utils/Libs/requestUrls';
+
+export const applyMassage = async (role: string) => {
+	try {
+		const { data } = await apiClient.put(MassageController.massage(role));
+		toast.success('안마의자 신청이 완료되었어요');
+		return { data };
+	} catch (e: any) {
+		if (e.message === 'Request failed with status code 409')
+			toast.warning('안마의자 신청 인원이 5명을 넘어 신청할 수 없어요');
+		else toast.warning('안마의자 신청을 할 수 없는 상태에요');
+	}
+};
+
+export const applyCancelMassage = async (role: string) => {
+	try {
+		const { data } = await apiClient.put(MassageController.cancelMassage(role));
+		toast.success('안마의자 신청이 취소 되었어요. 오늘 하루 동안 다시 신청이 불가능 해요');
+		return { data };
+	} catch (e) {}
+};
+
+export const applyModifyMassage = async (role: string, num:number) => {
+	try {
+		const { data } = await apiClient.put(MassageController.modifyMassage(role,num), {
+			number:num,
+		});
+		toast.success('안마의자 인원이 수정 되었어요');
+		return { data };
+	} catch (e) {}
+};

--- a/src/api/selfStudy.ts
+++ b/src/api/selfStudy.ts
@@ -1,0 +1,33 @@
+import { toast } from 'react-toastify';
+import { apiClient } from 'utils/Libs/apiClient';
+import { SelfstudyController } from 'utils/Libs/requestUrls';
+
+export const applySelfStudy = async (role: string) => {
+	try {
+		const { data } = await apiClient.put(SelfstudyController.selfStudy(role));
+		toast.success('자습 신청이 완료 되었어요');
+		return { data };
+	} catch (e: any) {
+		if (e.message === 'Request failed with status code 409')
+			toast.warning('자습 신청 인원이 50명이 넘어 신청하실 수 없어요');
+		else toast.warning('자습 신청을 할 수 없는 상태에요');
+	}
+};
+
+export const applyCancelStudy = async (role: string) => {
+	try {
+		const { data } = await apiClient.put(SelfstudyController.cancelStudy(role));
+		toast.success('자습 신청이 취소 되었어요');
+		return { data };
+	} catch (e) {}
+};
+
+export const applyModifyStudy = async (role: string, num:number) => {
+	try {
+		const { data } = await apiClient.put(SelfstudyController.modifyStudy(role,num), {
+			number:num,
+		});
+		toast.success('자습 인원이 수정 되었어요');
+		return { data };
+	} catch (e) {}
+};

--- a/src/components/Home/molecules/ApplyModifyModal/index.tsx
+++ b/src/components/Home/molecules/ApplyModifyModal/index.tsx
@@ -1,0 +1,39 @@
+import { AuthInput } from "components/Common";
+import ModalHeader from "components/Common/atoms/ModalHeader";
+import { ModalOverayWrapper } from "components/Home/atoms/Wrapper/style";
+import { useForm } from "react-hook-form";
+import { ApplyModifyModalProps } from "types";
+import { isNotNull } from "utils/isNotNull";
+import * as S from "./style";
+
+const ApplyModifyModal = ({modalState, setModalState, name, onClick, maxCount}:ApplyModifyModalProps) => {
+    const { register, watch, resetField } = useForm<{num:number}>({
+        defaultValues: {
+          num: maxCount,
+        },
+    });
+
+    return (
+        <ModalOverayWrapper isClick={modalState}>
+            <S.ApplyModifyModalWrapper>
+                <ModalHeader name={`${name} 인원 수정`} setState={setModalState} />
+                <div>
+                    <p>{`${name} 인원`}</p>
+                    <AuthInput
+                        register={register("num")}
+                        type="number"
+                        placeholder={`${maxCount}`}
+                        DeleteBtnClick={() => resetField('num')}
+                        isValue={isNotNull(watch('num').toString().replace(`${maxCount}`,''))}
+                    />
+                </div>
+                <S.BtnWrapper>
+                    <S.CancelBtn onClick={() => setModalState(false)}>취소</S.CancelBtn>
+                    <S.CheckBtn onClick={() => onClick(watch('num'))}>다음</S.CheckBtn>
+                </S.BtnWrapper>
+            </S.ApplyModifyModalWrapper>
+        </ModalOverayWrapper>
+    )
+}
+
+export default ApplyModifyModal;

--- a/src/components/Home/molecules/ApplyModifyModal/style.ts
+++ b/src/components/Home/molecules/ApplyModifyModal/style.ts
@@ -1,0 +1,61 @@
+import styled from "@emotion/styled";
+import { Palette } from "styles/globals";
+
+export const ApplyModifyModalWrapper = styled.div`
+	width: 410px;
+	height: 250px;
+	background: ${Palette.BACKGROUND_CARD};
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	z-index: 10;
+	padding: 12px 12px 20px 12px;
+	border-radius: 8px;
+	box-shadow: 0px 8px 24px rgba(0, 0, 0, 0.04);
+
+  p{
+      padding-left: 10px;
+      font-style: normal;
+      padding-bottom: 10px;
+      font-weight: 600;
+      font-size: 14px;
+      color: ${Palette.NEUTRAL_N10};
+    }
+
+    div{
+      width: 100%;
+    }
+
+	@media (max-width: 420px) {
+		width: 100%;
+		border-radius: 16px;
+	}
+`;
+
+export const BtnWrapper = styled.div`
+  height: 45px;
+  display: flex;
+  justify-content: center;
+  gap: 5px;
+
+  button{
+    width: 48.6%;
+    font-weight: 700;
+    font-size: 16px;
+    border-radius: 8px;
+  }
+`;
+
+export const CancelBtn = styled.button`
+  color: ${Palette.NEUTRAL_N20};
+  background-color: ${Palette.BACKGROUND_CARD};
+  border: 1px solid ${Palette.NEUTRAL_N30};
+`;
+
+export const CheckBtn = styled.button`
+  color: #fff;
+  background-color: ${Palette.PRIMARY_P10};
+  border: none;
+`;
+
+

--- a/src/components/Home/organisms/MassageBoard/index.tsx
+++ b/src/components/Home/organisms/MassageBoard/index.tsx
@@ -1,23 +1,89 @@
 import ApplyBox from "components/Home/molecules/ApplyBox";
 import { applyBoardState } from "types";
-import { useState } from "react";
+import { Dispatch, SetStateAction, useEffect, useState } from "react";
+import CommonCheckModal from "components/Common/molecules/CommonCheckModal";
+import ApplyModifyModal from "components/Home/molecules/ApplyModifyModal";
+import { applyCancelMassage, applyMassage, applyModifyMassage } from "api/massage";
 
 const MassageBoard = () => {
-    const [info, setInfo] = useState<applyBoardState>({ count: 4, applyStatus: '신청불가' });
+    const [info, setInfo] = useState<applyBoardState>({ count: 4, applyStatus: '안마의자' });
+    const [checkModal, setCheckModal] = useState(false);
+    const [applyModifyModal, setApplyModifyModal] = useState(false);
+    // const role = useRole()
+    const role:string = 'member'; // 예시
+
+    useEffect(() => {
+        if(role === 'admin'){
+            setInfo({...info, applyStatus: '인원수정'});
+        }
+    },[])
 
     const handleApplyBtnClick = () => {
-        
+        switch(info.applyStatus) {
+            case '안마의자'||'신청불가' :
+                return  StudyControll();
+            case '신청취소' : 
+                return setCheckModal(true);
+            case '인원수정' :
+                return setApplyModifyModal(true);
+        }
     }
+
+    const StudyControll = async (n?:number) => {
+        switch(info.applyStatus) {
+            case '안마의자' : {
+                // const {data}:any = await applyMassage(role);  
+                // if(data){}
+                setInfo({ count: info.count+1, applyStatus : '신청취소' });
+            }
+            return;
+            case '신청취소' : {
+                // await applyCancelMassage(role);
+                setInfo({ count: info.count-1, applyStatus : '신청불가' });
+            }
+            return;
+            case '인원수정' : {
+                // return await applyModifyMassage(role, n||50);
+            }
+        }
+    };
+
+    const handleModalClick = (setState:Dispatch<SetStateAction<boolean>>,n?:number) => {
+        setState(false);
+        StudyControll(n);
+    };
     
     return (
-        <ApplyBox 
-            name={"안마의자"} 
-            url={"/massage"} 
-            count={info.count} 
-            maxCount={5} 
-            applyStatus={info.applyStatus} 
-            onClick={handleApplyBtnClick}
-        />
+        <>    
+            <ApplyBox 
+                name={"안마의자"} 
+                url={"/massage"} 
+                count={info.count} 
+                maxCount={5} 
+                applyStatus={info.applyStatus} 
+                onClick={handleApplyBtnClick}
+            />
+             {
+                checkModal && 
+                <CommonCheckModal 
+                    title={"신청취소"}
+                    content={"오늘 하루동안 다시 신청이 불가능 해요"} 
+                    onClick={() => handleModalClick(setCheckModal)} 
+                    modalState={checkModal} 
+                    setModalState={setCheckModal}
+                />
+            }
+            {
+                applyModifyModal && 
+                <ApplyModifyModal 
+                    name={"자습"} 
+                    onClick={(n) => handleModalClick(setApplyModifyModal,n)}
+                    modalState={applyModifyModal} 
+                    setModalState={setApplyModifyModal}
+                    maxCount={50}
+                />
+            }
+        </>
     )
 }
 

--- a/src/components/Home/organisms/SelfStudyBoard/index.tsx
+++ b/src/components/Home/organisms/SelfStudyBoard/index.tsx
@@ -1,23 +1,90 @@
+import { applyCancelStudy, applyModifyStudy, applySelfStudy } from "api/selfStudy";
+import CommonCheckModal from "components/Common/molecules/CommonCheckModal";
 import ApplyBox from "components/Home/molecules/ApplyBox";
-import { useEffect, useState } from "react";
+import ApplyModifyModal from "components/Home/molecules/ApplyModifyModal";
+import { useRole } from "hooks/useRole";
+import { Dispatch, SetStateAction, useEffect, useState } from "react";
 import { applyBoardState } from "types";
 
 const SelfStudyBoard = () => {
     const [info, setInfo] = useState<applyBoardState>({ count: 25, applyStatus: '신청취소' });
+    const [checkModal, setCheckModal] = useState(false);
+    const [applyModifyModal, setApplyModifyModal] = useState(false);
+    // const role = useRole()
+    const role:string = 'member'; // 예시
+
+    useEffect(() => {
+        if(role === 'admin'){
+            setInfo({...info, applyStatus: '인원수정'});
+        }
+    },[])
 
     const handleApplyBtnClick = () => {
-        
+        switch(info.applyStatus) {
+            case '자습신청'||'신청불가' :
+                return  StudyControll();
+            case '신청취소' : 
+                return setCheckModal(true);
+            case '인원수정' :
+                return setApplyModifyModal(true);
+        }
     }
 
+    const StudyControll = async (n?:number) => {
+        switch(info.applyStatus) {
+            case '자습신청' : {
+                // const {data}:any = await applySelfStudy(role);  
+                // if(data){}
+                setInfo({ count: info.count+1, applyStatus : '신청취소' });
+            }
+            return;
+            case '신청취소' : {
+                // await applyCancelStudy(role);
+                setInfo({ count: info.count-1, applyStatus : '신청불가' });
+            }
+            return;
+            case '인원수정' : {
+                // return await applyModifyStudy(role, n||50);
+            }
+        }
+    };
+
+    const handleModalClick = (setState:Dispatch<SetStateAction<boolean>>,n?:number) => {
+        setState(false);
+        StudyControll(n);
+    };
+
     return (
-       <ApplyBox 
-            name={"자습신청"} 
-            url={"/selfstudy"} 
-            count={info.count} 
-            maxCount={50} 
-            applyStatus={info.applyStatus} 
-            onClick={handleApplyBtnClick}
-        />
+        <>
+            <ApplyBox 
+                name={"자습신청"} 
+                url={"/selfstudy"} 
+                count={info.count} 
+                maxCount={50} 
+                applyStatus={info.applyStatus}
+                onClick={handleApplyBtnClick}
+            />
+            {
+                checkModal && 
+                <CommonCheckModal 
+                    title={"신청취소"}
+                    content={"오늘 하루동안 다시 신청이 불가능 해요"} 
+                    onClick={() => handleModalClick(setCheckModal)} 
+                    modalState={checkModal} 
+                    setModalState={setCheckModal}
+                />
+            }
+            {
+                applyModifyModal && 
+                <ApplyModifyModal 
+                    name={"자습"} 
+                    onClick={(n) => handleModalClick(setApplyModifyModal,n)}
+                    modalState={applyModifyModal} 
+                    setModalState={setApplyModifyModal}
+                    maxCount={50}
+                />
+            }
+        </>
     )
 }
 

--- a/src/types/Home.ts
+++ b/src/types/Home.ts
@@ -1,5 +1,5 @@
 export interface applyStyleProps {
-    applyStatus: "신청취소"|"신청불가"|"자습신청"|"안마의자"
+    applyStatus: "신청취소"|"신청불가"|"자습신청"|"안마의자"|"인원수정"
 }
 
 export interface applyBoardState extends applyStyleProps {

--- a/src/types/Modals.ts
+++ b/src/types/Modals.ts
@@ -36,3 +36,9 @@ export interface CommonCheckModalProps extends ModalProps {
   content: string;
   onClick: () => void;
 }
+
+export interface ApplyModifyModalProps extends ModalProps {
+  name: string;
+  maxCount: number;
+  onClick: (n:number) => void;
+}

--- a/src/utils/Libs/requestUrls.ts
+++ b/src/utils/Libs/requestUrls.ts
@@ -6,7 +6,6 @@ export const MemberController = {
 	changePasswd: '/changePasswd',
 }
 
-//토큰 재발급
 export const TokenController = {
 	reissue: '/reissue'
 };
@@ -15,3 +14,15 @@ export const BoardController = {
 	board: '/board',
 	boardId(boardIdx:number) {return `/board/${boardIdx}`},
 };
+
+export const SelfstudyController = {
+	selfStudy(role: string){return `/${role}/selfstudy`},
+	cancelStudy(role: string){return `/${role}/cancel/selfstudy`},
+	modifyStudy(role: string,num:number){return `/${role}/modify/selfstudy/${num}`},
+};
+
+export const MassageController = {
+	massage(role: string){return `/${role}/massage`},
+	cancelMassage(role: string){return `/${role}/cancel/massage`},
+	modifyMassage(role: string,num:number){return `/${role}/modify/massage/${num}`},
+}


### PR DESCRIPTION
## 🔍 개요
자습,안마의자 기능추가
## 📃 작업사항
사감쌤시 버튼이 인원수정으로바뀌고 인원수정할 수 있게 했습니다.
자습취소 모달 추가했습니다.
자습,안마의자 부분 기능구현 했습니다.

- 인원수정클릭시
![image](https://user-images.githubusercontent.com/82823150/223968064-464e5f99-abff-46d7-bd7a-2f17fcd651d8.png)

- 인원 입력시
![image](https://user-images.githubusercontent.com/82823150/223968145-db5cc0cb-7711-416b-a4a9-12ced5e1411f.png)

- 신청취소 클릭시
![image](https://user-images.githubusercontent.com/82823150/223968189-41ae6d20-350a-497e-b90b-8d54584d98ab.png)
