### PR TITLE
Fix : noticeBoard 수정

### DIFF
--- a/src/components/Home/organisms/NoticeBoard/index.tsx
+++ b/src/components/Home/organisms/NoticeBoard/index.tsx
@@ -24,16 +24,8 @@ const NoticeBoard = () => {
         {boardList ? (
           boardList.map((i, idx) => (
             <S.NoticeBox key={idx}>
-              <NoticeItem
-                writer={i.role}
-                date={i.createdDate.slice(0, 10)}
-                title={i.title}
-                desc={i.content}
-                isCurrenPage={false}
-                id={i.id}
-              />
-              {boardList[idx]?.createdDate.slice(0, 7) >
-                boardList[idx + 1]?.createdDate.slice(0, 7) && (
+              {boardList[idx]?.createdDate.slice(0, 7) <
+                boardList[idx - 1]?.createdDate.slice(0, 7) && (
                 <S.DateLine>
                   <hr />
                   {`${i?.createdDate.slice(0, 4)}년 ${i?.createdDate.slice(
@@ -43,6 +35,14 @@ const NoticeBoard = () => {
                   <hr />
                 </S.DateLine>
               )}
+              <NoticeItem
+                writer={i.role}
+                date={i.createdDate.slice(0, 10)}
+                title={i.title}
+                desc={i.content}
+                isCurrenPage={false}
+                id={i.id}
+              />
             </S.NoticeBox>
           ))
         ) : (

--- a/src/components/Home/organisms/NoticeBoard/style.ts
+++ b/src/components/Home/organisms/NoticeBoard/style.ts
@@ -39,7 +39,8 @@ export const NoticeList = styled.div`
   align-items: center;
   overflow-y: auto;
   margin: 0 auto;
-  gap: 20px;
+  gap: 13px;
+  padding-bottom: 12%;
 
   ::-webkit-scrollbar {
     width: 0px;


### PR DESCRIPTION
## 🔍 개요
기존 공지사항 List 에 중간선 구분을 반대로 해놓았습니다.
공지사항 마지막 아이템을 그림자 시작부분까지 스크롤 되게 변경했습니다.
## 📃 작업사항

## 🔀 변경로직

## 🎸 기타
