### PR TITLE
🔀 기상음악 페이지 트러블 슈팅

### DIFF
--- a/src/api/music.ts
+++ b/src/api/music.ts
@@ -39,6 +39,7 @@ export const deleteMusic = async (role: string, musicId: number) => {
     toast.success('음악삭제를 성공하셨습니다');
     return true;
   } catch (e) {
+    toast.error('삭제하려는 음악을 찾지 못했습니다');
     return false;
   }
 };

--- a/src/assets/svg/MusicNoteIcon.tsx
+++ b/src/assets/svg/MusicNoteIcon.tsx
@@ -1,54 +1,70 @@
+import { Palette } from 'styles/globals';
+
 const MusicalNoteIcon = () => {
   return (
     <svg
-      width="28"
-      height="28"
-      viewBox="0 0 28 28"
+      width="120"
+      height="122"
+      viewBox="0 0 120 122"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
     >
       <circle
-        cx="9.81057"
-        cy="20.7514"
-        r="2.30089"
-        transform="rotate(15 9.81057 20.7514)"
-        stroke="#818198"
-        strokeWidth="1.5"
+        cx="37.0577"
+        cy="94.757"
+        r="11.5045"
+        transform="rotate(15 37.0577 94.757)"
+        stroke={Palette.NEUTRAL_N20}
+        strokeWidth="8"
       />
       <circle
-        cx="19.987"
-        cy="21.4073"
-        r="2.30186"
-        transform="rotate(15 19.987 21.4073)"
-        stroke="#818198"
-        strokeWidth="1.5"
+        cx="87.9352"
+        cy="98.0393"
+        r="11.5093"
+        transform="rotate(15 87.9352 98.0393)"
+        stroke={Palette.NEUTRAL_N20}
+        strokeWidth="8"
       />
       <path
-        d="M22.2106 22.0031L24.54 13.3098M12.0337 21.3468L14.3631 12.6535M14.3631 12.6535L15.3984 8.78976C20.0348 10.0321 23.7929 9.65869 25.5753 9.4461L24.54 13.3098M14.3631 12.6535C16.4559 13.2142 20.6486 13.9235 24.54 13.3098"
-        stroke="#818198"
-        strokeWidth="1.5"
+        d="M99.0537 101.017L110.7 57.5505M48.1691 97.7355L59.816 54.2688M59.816 54.2688L64.9924 34.9503C88.1746 41.1619 106.965 39.2949 115.877 38.232L110.7 57.5505M59.816 54.2688C70.2802 57.0727 91.2433 60.6191 110.7 57.5505"
+        stroke={Palette.NEUTRAL_N20}
+        strokeWidth="8"
         strokeLinecap="round"
         strokeLinejoin="round"
       />
       <path
-        d="M12.0318 21.3468L15.3965 8.78979"
-        stroke="#818198"
-        strokeWidth="1.5"
+        d="M59.8151 54.2681C70.2793 57.072 91.2424 60.6185 110.7 57.5498"
+        stroke={Palette.NEUTRAL_N30}
+        strokeWidth="8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M48.169 97.7342L64.9922 34.9492"
+        stroke={Palette.NEUTRAL_N20}
+        strokeWidth="8"
         strokeLinecap="round"
         strokeLinejoin="round"
       />
       <circle
-        cx="2"
-        cy="2"
-        r="2"
-        transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 9.84961 9.97437)"
-        stroke="#818198"
-        strokeWidth="1.5"
+        cx="10"
+        cy="10"
+        r="10"
+        transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 37.2495 40.873)"
+        stroke={Palette.NEUTRAL_N20}
+        strokeWidth="8"
       />
       <path
-        d="M5.60693 8.56006L10.5566 3.61035C9.49598 3.96391 8.43532 4.31746 7.02111 3.61035"
-        stroke="#818198"
-        strokeWidth="1.5"
+        d="M16.0342 33.8003L40.7827 9.05176C35.4794 10.8195 30.1761 12.5873 23.105 9.05176"
+        stroke={Palette.NEUTRAL_N20}
+        strokeWidth="8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M40.7822 9.05176C35.4789 10.8195 30.1756 12.5873 23.1046 9.05176"
+        stroke={Palette.NEUTRAL_N30}
+        strokeWidth="8"
         strokeLinecap="round"
         strokeLinejoin="round"
       />

--- a/src/assets/svg/index.ts
+++ b/src/assets/svg/index.ts
@@ -50,3 +50,5 @@ export { default as EyeIcon } from './EyeIcon';
 export { default as EyeSelectedIcon } from './EyeSelectedIcon';
 export { default as MusicalNoteIcon } from './MusicNoteIcon';
 export { default as EllipsisVerticalIcon } from './EllipsisVerticalIcon';
+export { default as NewPageIcon } from './NewPageIcon';
+export { default as TrashcanIcon } from './TrashcanIcon';

--- a/src/components/Common/atoms/Calendar/style.ts
+++ b/src/components/Common/atoms/Calendar/style.ts
@@ -10,13 +10,16 @@ export const Layer = styled.div`
   }
 
   .react-calendar {
-    max-width: 380px;
     background: ${Palette.BACKGROUND_CARD};
     color: #222;
-    border-radius: 0.5em;
+    border-radius: 1em;
     padding: 1.5em;
     box-shadow: 0px 8px 24px rgba(0, 0, 0, 0.04);
     font-family: Arial, Helvetica, sans-serif;
+
+    @media (max-width: 951px) {
+      max-width: 380px;
+    }
   }
 
   .react-calendar__navigation {
@@ -70,9 +73,8 @@ export const Layer = styled.div`
         props.state === 'light' ? '#F2F2F4' : '#fff'};
       font-size: 14px;
 
-      :enabled:hover,
       :enabled:focus {
-        background: #ed7878;
+        background: ${Palette.PRIMARY_P10};
         color: ${(props: { state: string }) =>
           props.state === 'light' ? '#F2F2F4' : '#fff'};
       }
@@ -90,6 +92,7 @@ export const Layer = styled.div`
     background: ${Palette.NEUTRAL_N40};
     color: #6d92c4;
     border-radius: 0.5em;
+    font-weight: normal;
   }
 
   .react-calendar__tile--active {
@@ -107,7 +110,6 @@ export const Layer = styled.div`
         props.state === 'light' ? '#F2F2F4' : '#fff'};
     }
   }
-  position: relative;
 `;
 
 export const XIcon = styled.div`

--- a/src/components/Common/molecules/CommonCheckModal/index.tsx
+++ b/src/components/Common/molecules/CommonCheckModal/index.tsx
@@ -1,6 +1,8 @@
-import * as S from './style';
 import { ModalOverayWrapper } from 'components/Common/atoms/Wrappers/ModalOverayWrapper/style';
+import { MouseEvent } from 'react';
 import { CommonCheckModalProps } from 'types';
+import { preventEvent } from 'utils/Libs/preventEvent';
+import * as S from './style';
 
 const CommonCheckModal = ({
   modalState,
@@ -9,13 +11,26 @@ const CommonCheckModal = ({
   content,
   onClick,
 }: CommonCheckModalProps) => (
-  <ModalOverayWrapper isClick={modalState} onClick={() => setModalState(false)}>
-    <S.CheckModalWrapper onClick={(e) => e.stopPropagation()}>
+  <ModalOverayWrapper
+    isClick={modalState}
+    onClick={(e: MouseEvent) => {
+      preventEvent(e);
+      setModalState(false);
+    }}
+  >
+    <S.CheckModalWrapper onClick={preventEvent}>
       <S.CheckTitle>{title}</S.CheckTitle>
       <S.CheckContent>{content}</S.CheckContent>
       <S.BtnWrapper>
         <S.CancelBtn onClick={() => setModalState(false)}>취소</S.CancelBtn>
-        <S.CheckBtn onClick={onClick}>확인</S.CheckBtn>
+        <S.CheckBtn
+          onClick={() => {
+            onClick();
+            setModalState(false);
+          }}
+        >
+          확인
+        </S.CheckBtn>
       </S.BtnWrapper>
     </S.CheckModalWrapper>
   </ModalOverayWrapper>

--- a/src/components/Song/molecules/NoticeModal/style.ts
+++ b/src/components/Song/molecules/NoticeModal/style.ts
@@ -23,7 +23,7 @@ export const ContentBox = styled.div`
   height: 100%;
   padding: 1rem;
   background: ${Palette.NEUTRAL_N40};
-  border-radius: 1rem;
+  border-radius: 0.5em;
 `;
 
 export const ContentList = styled.ul`

--- a/src/components/Song/molecules/SongItem/index.tsx
+++ b/src/components/Song/molecules/SongItem/index.tsx
@@ -4,16 +4,16 @@ import TrashcanIcon from 'assets/svg/TrashcanIcon';
 import axios from 'axios';
 import Image from 'next/image';
 import Link from 'next/link';
-import { useEffect, useState } from 'react';
+import { MouseEvent, useEffect, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import { selectedDate } from 'recoilAtoms/recoilAtomContainer';
 import useSWR, { mutate } from 'swr';
+import { myProfileType } from 'types';
 import { SongType } from 'types/components/SongPage';
 import { getRole } from 'utils/Libs/getRole';
+import { MemberController, SongController } from 'utils/Libs/requestUrls';
 import { getDate } from 'utils/getDate';
 import * as S from './style';
-import { MemberController, SongController } from 'utils/Libs/requestUrls';
-import { myProfileType } from 'types';
 
 const songTitle = async (url: string) => {
   const api_key = process.env.NEXT_PUBLIC_YOUTUBE_API_KEY;
@@ -57,41 +57,47 @@ const SongItem = ({ data: songData }: { data: SongType }) => {
   };
 
   return (
-    <S.Layer>
-      <S.LeftWrapper>
-        <S.ImgBox>
-          <Image
-            src={`https://img.youtube.com/vi/${youtubeId}/sddefault.jpg`}
-            alt={'image'}
-            layout="fill"
-            objectFit="cover"
-          />
-        </S.ImgBox>
-        <S.Title>{title}</S.Title>
-      </S.LeftWrapper>
-      <S.StuInfo>
-        <p>{songData.stuNum}</p>
-        <p>{songData.username}</p>
-      </S.StuInfo>
-      <S.CreateDate>{songDate}</S.CreateDate>
-      <S.ButtonContainer>
-        {(role !== 'member' ||
-          String(songData.stuNum) === userData?.stuNum) && (
-          <button
-            onClick={() => {
-              onDelete(songData.id);
-            }}
-          >
-            <TrashcanIcon />
-          </button>
-        )}
-        <Link href={songData.url}>
-          <a>
+    <Link
+      href={songData.url}
+      onClick={(e: MouseEvent) => {
+        e.preventDefault();
+      }}
+    >
+      <a target="_blank">
+        <S.LeftWrapper>
+          <S.ImgBox>
+            <Image
+              src={`https://img.youtube.com/vi/${youtubeId}/sddefault.jpg`}
+              alt={'image'}
+              layout="fill"
+              objectFit="cover"
+            />
+          </S.ImgBox>
+          <S.Title>{title}</S.Title>
+        </S.LeftWrapper>
+        <S.StuInfo>
+          <p>{songData.stuNum}</p>
+          <p>{songData.username}</p>
+        </S.StuInfo>
+        <S.CreateDate>{songDate}</S.CreateDate>
+        <S.ButtonContainer>
+          {(role !== 'member' ||
+            String(songData.stuNum) === userData?.stuNum) && (
+            <button
+              onClick={(e: MouseEvent) => {
+                e.preventDefault();
+                onDelete(songData.id);
+              }}
+            >
+              <TrashcanIcon />
+            </button>
+          )}
+          <div>
             <NewPageIcon />
-          </a>
-        </Link>
-      </S.ButtonContainer>
-    </S.Layer>
+          </div>
+        </S.ButtonContainer>
+      </a>
+    </Link>
   );
 };
 

--- a/src/components/Song/molecules/SongItem/index.tsx
+++ b/src/components/Song/molecules/SongItem/index.tsx
@@ -1,16 +1,17 @@
 import { deleteMusic, getMusic } from 'api/music';
-import NewPageIcon from 'assets/svg/NewPageIcon';
-import TrashcanIcon from 'assets/svg/TrashcanIcon';
+import { NewPageIcon, TrashcanIcon } from 'assets/svg';
 import axios from 'axios';
+import CommonCheckModal from 'components/Common/molecules/CommonCheckModal';
 import Image from 'next/image';
 import Link from 'next/link';
-import { MouseEvent, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import { selectedDate } from 'recoilAtoms/recoilAtomContainer';
 import useSWR, { mutate } from 'swr';
 import { myProfileType } from 'types';
 import { SongType } from 'types/components/SongPage';
 import { getRole } from 'utils/Libs/getRole';
+import { preventEvent } from 'utils/Libs/preventEvent';
 import { MemberController, SongController } from 'utils/Libs/requestUrls';
 import { getDate } from 'utils/getDate';
 import * as S from './style';
@@ -34,8 +35,9 @@ const youtube_parser = (url: string) => {
 const SongItem = ({ data: songData }: { data: SongType }) => {
   const role = getRole();
   const youtubeId = youtube_parser(songData.url);
-  const [title, setTitle] = useState('');
+  const [title, setTitle] = useState<string>('');
   const { data: userData } = useSWR<myProfileType>(MemberController.myProfile);
+  const [deleteModal, setDeleteModal] = useState<boolean>(false);
 
   const createdDate = new Date(songData.createdTime);
   const songDate = `${getDate(createdDate)[3]}시 ${getDate(createdDate)[4]}분`;
@@ -57,12 +59,7 @@ const SongItem = ({ data: songData }: { data: SongType }) => {
   };
 
   return (
-    <Link
-      href={songData.url}
-      onClick={(e: MouseEvent) => {
-        e.preventDefault();
-      }}
-    >
+    <Link href={songData.url}>
       <a target="_blank">
         <S.LeftWrapper>
           <S.ImgBox>
@@ -84,9 +81,9 @@ const SongItem = ({ data: songData }: { data: SongType }) => {
           {(role !== 'member' ||
             String(songData.stuNum) === userData?.stuNum) && (
             <button
-              onClick={(e: MouseEvent) => {
-                e.preventDefault();
-                onDelete(songData.id);
+              onClick={(e) => {
+                preventEvent(e);
+                setDeleteModal(true);
               }}
             >
               <TrashcanIcon />
@@ -96,6 +93,14 @@ const SongItem = ({ data: songData }: { data: SongType }) => {
             <NewPageIcon />
           </div>
         </S.ButtonContainer>
+
+        <CommonCheckModal
+          title="신청 음악 삭제"
+          content="신청 음악을 정말 삭제하시겠습니까?"
+          modalState={deleteModal}
+          setModalState={setDeleteModal}
+          onClick={() => onDelete(songData.id)}
+        />
       </a>
     </Link>
   );

--- a/src/components/Song/molecules/SongItem/index.tsx
+++ b/src/components/Song/molecules/SongItem/index.tsx
@@ -38,7 +38,7 @@ const SongItem = ({ data: songData }: { data: SongType }) => {
   const { data: userData } = useSWR<myProfileType>(MemberController.myProfile);
 
   const createdDate = new Date(songData.createdTime);
-  const songDate = `${getDate(createdDate)[1]}월 ${getDate(createdDate)[2]}일`;
+  const songDate = `${getDate(createdDate)[3]}시 ${getDate(createdDate)[4]}분`;
   const date = useRecoilValue(selectedDate);
   const postDate = `${getDate(date)[0]}-${getDate(date)[1]}-${
     getDate(date)[2]

--- a/src/components/Song/molecules/SongItem/style.ts
+++ b/src/components/Song/molecules/SongItem/style.ts
@@ -1,7 +1,8 @@
 import styled from '@emotion/styled';
+import Link from 'next/link';
 import { Palette } from 'styles/globals';
 
-export const Layer = styled.div`
+export const Layer = styled(Link)`
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -66,7 +67,7 @@ export const ButtonContainer = styled.div`
   justify-content: end;
 
   button,
-  a {
+  div {
     border: none;
     border-radius: 0.5em;
     background: ${Palette.BACKGROUND_BG};

--- a/src/components/Song/organisms/SongList/index.tsx
+++ b/src/components/Song/organisms/SongList/index.tsx
@@ -7,8 +7,8 @@ import useSWR from 'swr';
 import { SongListType } from 'types/components/SongPage';
 import { getRole } from 'utils/Libs/getRole';
 import { SongController } from 'utils/Libs/requestUrls';
-import * as S from './style';
 import { getDate } from 'utils/getDate';
+import * as S from './style';
 
 const SongList = () => {
   const role = getRole();

--- a/src/components/Song/organisms/SongList/index.tsx
+++ b/src/components/Song/organisms/SongList/index.tsx
@@ -1,4 +1,5 @@
 import { getMusic } from 'api/music';
+import { MusicalNoteIcon } from 'assets/svg';
 import SongItem from 'components/Song/molecules/SongItem';
 import { useEffect } from 'react';
 import { useRecoilValue } from 'recoil';
@@ -34,7 +35,15 @@ const SongList = () => {
         </p>
       </S.ListHeader>
       <S.ListContainer>
-        {data && data.content?.map((i) => <SongItem key={i.id} data={i} />)}
+        {data && data.content?.length > 0 ? (
+          data.content?.map((i) => <SongItem key={i.id} data={i} />)
+        ) : (
+          <S.EmptySongBox>
+            <MusicalNoteIcon />
+            <h2>아직 신청한 음악이 없습니다..</h2>
+            <p>오른쪽 위에서 음악 신청을 해보세요!</p>
+          </S.EmptySongBox>
+        )}
       </S.ListContainer>
     </S.Layer>
   );

--- a/src/components/Song/organisms/SongList/style.ts
+++ b/src/components/Song/organisms/SongList/style.ts
@@ -67,3 +67,17 @@ export const ListContainer = styled.div`
     text-decoration: none;
   }
 `;
+
+export const EmptySongBox = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  gap: 0.5em;
+
+  h2 {
+    margin-top: 0.75em;
+  }
+`;

--- a/src/components/Song/organisms/SongList/style.ts
+++ b/src/components/Song/organisms/SongList/style.ts
@@ -79,5 +79,9 @@ export const EmptySongBox = styled.div`
 
   h2 {
     margin-top: 0.75em;
+    color: ${Palette.NEUTRAL_N10};
+  }
+  p {
+    color: ${Palette.NEUTRAL_N20};
   }
 `;

--- a/src/components/Song/organisms/SongList/style.ts
+++ b/src/components/Song/organisms/SongList/style.ts
@@ -48,4 +48,22 @@ export const ListContainer = styled.div`
   ::-webkit-scrollbar {
     width: 0;
   }
+
+  & > a {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+    height: 72px;
+    transition: 0.2s;
+    border-radius: 0.5em;
+    padding: 0.5em 0.5em 0.5em 0;
+
+    :hover {
+      background: ${Palette.NEUTRAL_N50};
+    }
+  }
+  & > a:-webkit-any-link {
+    text-decoration: none;
+  }
 `;

--- a/src/components/Song/template/style.ts
+++ b/src/components/Song/template/style.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 export const SongTemplate = styled.div`
-  padding: 0 72px;
+  padding: 0 72px 56px 72px;
   width: calc(100% - 240px);
   height: 100%;
   display: flex;

--- a/src/components/Song/template/style.ts
+++ b/src/components/Song/template/style.ts
@@ -1,23 +1,5 @@
 import styled from '@emotion/styled';
 
-export const SongTemplate = styled.div`
-  padding: 0 72px 56px 72px;
-  width: calc(100% - 240px);
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  gap: 1rem;
-
-  @media (max-width: 1634px) {
-    width: calc(100% - 72px);
-  }
-  @media (max-width: 420px) {
-    width: 100%;
-    padding: 0 1.25rem;
-  }
-`;
-
 export const SongLayer = styled.div`
   width: 100%;
   height: calc(100% - 130px);

--- a/src/pages/song.tsx
+++ b/src/pages/song.tsx
@@ -1,5 +1,5 @@
-import { getMusic } from 'api/music';
 import SEOHead from 'components/Common/atoms/SEOHead';
+import { CommonPageWrapper } from 'components/Common/atoms/Wrappers/CommonPageWrapper/style';
 import CommonHeader from 'components/Common/organisms/CommonHeader';
 import SideBar from 'components/Common/organisms/Sidebar';
 import { MainTemplates } from 'components/Common/templates/MainTemplates/style';
@@ -7,10 +7,9 @@ import NoticeModal from 'components/Song/molecules/NoticeModal';
 import SongList from 'components/Song/organisms/SongList';
 import SongModal from 'components/Song/organisms/SongModal';
 import SongRightLayer from 'components/Song/organisms/SongRightLayer';
-import * as S from 'components/Song/template/style';
+import { SongLayer } from 'components/Song/template/style';
 import UseThemeEffect from 'hooks/useThemeEffect';
 import { GetServerSideProps, NextPage } from 'next';
-import { useRecoilValue } from 'recoil';
 import { SWRConfig } from 'swr';
 import { SongListType } from 'types/components/SongPage';
 import { apiClient } from 'utils/Libs/apiClient';
@@ -29,13 +28,13 @@ const SongPage: NextPage<{
       <SWRConfig value={fallback}>
         <MainTemplates>
           <SideBar />
-          <S.SongTemplate>
+          <CommonPageWrapper>
             <CommonHeader />
-            <S.SongLayer>
+            <SongLayer>
               <SongList />
               <SongRightLayer />
-            </S.SongLayer>
-          </S.SongTemplate>
+            </SongLayer>
+          </CommonPageWrapper>
           <SongModal />
           <NoticeModal />
         </MainTemplates>

--- a/src/utils/Libs/preventEvent.ts
+++ b/src/utils/Libs/preventEvent.ts
@@ -1,0 +1,6 @@
+import { MouseEvent } from 'react';
+
+export const preventEvent = (e: MouseEvent) => {
+  e.preventDefault();
+  e.stopPropagation();
+};


### PR DESCRIPTION
## 🔍 개요
기상음악 페이지 트러블 슈팅 했습니다

- 기상음악을 유튜브에서 띄울 때 새 창으로 이동하기
- 기상음악 신청일 대신 신청시간 띄우기
- 반응형 웹에 따른 달력 크기 수정하기
- 기상음악 삭제 전 alert 띄우기
- 기상음악 리스트 비어있을 때 메시지 띄우기
- 음악신청 페이지 radius와 같은 자잘한 디자인 수정

## 📃 작업사항
| 주제 | 자료 |
|-----|-----|
| 기상음악을 유튜브에서 띄울 때 새 창으로 이동하기 , 기상음악 신청일 대신 신청시간 띄우기 | <video src="https://github.com/Team-Ampersand/Dotori-client-v2/assets/87346613/8b44b10b-b533-428b-8794-3e7b810a76f5">|
| 기상음악 리스트 비어있을 때 메시지 띄우기 | <img width="1792" alt="image" src="https://github.com/Team-Ampersand/Dotori-client-v2/assets/87346613/d6c4f003-0d91-4e81-a522-1fd2eb22f31f"> |
| 기상음악 삭제 전 alert 띄우기 | <img width="1791" alt="image" src="https://github.com/Team-Ampersand/Dotori-client-v2/assets/87346613/512edf6a-e5a1-4e57-80d2-f39c395910a4"> |
| 반응형 웹에 따른 달력 크기 | <img width="1282" alt="image" src="https://github.com/Team-Ampersand/Dotori-client-v2/assets/87346613/dde4e442-aaad-4970-b2f6-6fdee6ca0040"> |
| border, color 등 자잘한 디자인 수정하기 | |




## 🔀 변경로직

## 🎸 기타
