### PR TITLE
[#158] :: 🔀 학생정보 페이지 디자인 이슈 수정

### DIFF
--- a/src/components/StuInfo/molecules/StuInfoItem/style.ts
+++ b/src/components/StuInfo/molecules/StuInfoItem/style.ts
@@ -11,7 +11,7 @@ export const Layer = styled.div`
   font-size: 0.875em;
   color: ${Palette.NEUTRAL_N20};
   border-radius: 1em;
-  padding: 0 0.5em;
+  padding: 1em 0.5em;
 
   :hover {
     background: ${Palette.BACKGROUND_BG};

--- a/src/components/StuInfo/organisms/StuInfoList/index.tsx
+++ b/src/components/StuInfo/organisms/StuInfoList/index.tsx
@@ -43,10 +43,12 @@ const StuInfoList = () => {
           <span>{infoList?.length}</span> 명
         </p>
       </S.ListHeader>
-      {!!infoList &&
-        infoList?.map((item: StuInfoType) => (
-          <StuInfoItem key={item.id} data={item} />
-        ))}
+      <S.ListContent>
+        {!!infoList &&
+          infoList.map((item: StuInfoType) => (
+            <StuInfoItem key={item.id} data={item} />
+          ))}
+      </S.ListContent>
     </S.Layer>
   );
 };

--- a/src/components/StuInfo/organisms/StuInfoList/style.ts
+++ b/src/components/StuInfo/organisms/StuInfoList/style.ts
@@ -7,15 +7,15 @@ export const Layer = styled.div`
   background: ${Palette.BACKGROUND_CARD};
   border-radius: 1rem;
   padding: 1.5rem 1rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5em;
 `;
 
 export const ListHeader = styled.div`
   display: flex;
   align-items: center;
   gap: 0.5em;
+  height: 5%;
+  margin-bottom: 1em;
+  padding: 0 0.5em;
 
   > h3 {
     color: ${Palette.NEUTRAL_N10};
@@ -26,4 +26,12 @@ export const ListHeader = styled.div`
       color: ${Palette.PRIMARY_P10};
     }
   }
+`;
+
+export const ListContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5em;
+  overflow-y: auto;
+  height: 95%;
 `;

--- a/src/components/StuInfo/template/style.ts
+++ b/src/components/StuInfo/template/style.ts
@@ -1,15 +1,5 @@
 import styled from '@emotion/styled';
 
-export const StuInfoTemplate = styled.div`
-  width: calc(100% - 240px);
-  height: 100%;
-  padding: 0 72px;
-
-  @media (max-width: 1634px) {
-    width: calc(100% - 72px);
-  }
-`;
-
 export const StuInfoLayer = styled.div`
   width: 100%;
   height: calc(100% - 114px);

--- a/src/pages/studsDetail.tsx
+++ b/src/pages/studsDetail.tsx
@@ -1,13 +1,11 @@
 import SEOHead from 'components/Common/atoms/SEOHead';
+import { CommonPageWrapper } from 'components/Common/atoms/Wrappers/CommonPageWrapper/style';
 import CommonHeader from 'components/Common/organisms/CommonHeader';
 import SideBar from 'components/Common/organisms/Sidebar';
 import { MainTemplates } from 'components/Common/templates/MainTemplates/style';
 import StuInfoForm from 'components/StuInfo/organisms/StuInfoForm';
 import StuInfoList from 'components/StuInfo/organisms/StuInfoList';
-import {
-  StuInfoLayer,
-  StuInfoTemplate,
-} from 'components/StuInfo/template/style';
+import { StuInfoLayer } from 'components/StuInfo/template/style';
 import { GetServerSideProps, NextPage } from 'next';
 import { SWRConfig } from 'swr';
 import { StuInfoType } from 'types/components/StuInfoPage';
@@ -24,13 +22,13 @@ const StudsDetail: NextPage<{
       <SWRConfig value={fallback}>
         <MainTemplates>
           <SideBar />
-          <StuInfoTemplate>
+          <CommonPageWrapper>
             <CommonHeader />
             <StuInfoLayer>
               <StuInfoList />
               <StuInfoForm />
             </StuInfoLayer>
-          </StuInfoTemplate>
+          </CommonPageWrapper>
         </MainTemplates>
       </SWRConfig>
     </>


### PR DESCRIPTION
## 🔍 개요
![image](https://github.com/Team-Ampersand/Dotori-client-v2/assets/87346613/2c32dd1d-a1a3-4e29-b1ec-2a97df70e840)
- 학생정보 리스트에서 contents가 리스트 높이를 overflow 할 때 부자연스러운 디자인이 있었습니다.
- 학생정보 리스트에서 content간의 간격이 좁아 보입니다.

## 📃 작업사항
https://github.com/Team-Ampersand/Dotori-client-v2/assets/87346613/50deea35-3cf4-4c05-8da2-d9f979c5adbd

## 🔀 변경로직

## 🎸 기타
