### PR TITLE
🔀 자습 신청 마지막 순위 스탬프 아이콘 표시

### DIFF
--- a/src/components/Common/molecules/ApplicationItem/index.tsx
+++ b/src/components/Common/molecules/ApplicationItem/index.tsx
@@ -18,6 +18,7 @@ const ApplicationItem = ({
   gender,
   stuNum,
   listType,
+  lastRank,
 }: ApplicationItemProps) => {
   const role = getRole();
   const lookUp = useRecoilValue(selfStudyLookup);
@@ -56,7 +57,7 @@ const ApplicationItem = ({
                   height={64}
                 />
               )}
-              {rank === 50 && <StampIcon />}
+              {rank === lastRank && <StampIcon />}
             </S.Medal>
           )}
           {role !== 'member' && (

--- a/src/components/SelfStudy/molecules/SelfStudyList/index.tsx
+++ b/src/components/SelfStudy/molecules/SelfStudyList/index.tsx
@@ -17,6 +17,7 @@ const SelfStudyList = () => {
             memberName={item.memberName}
             gender={item.gender}
             stuNum={item.stuNum}
+            lastRank={userList.length > 3 ? userList.length : 0}
             listType="selfstudy"
           />
         ))}

--- a/src/types/List.ts
+++ b/src/types/List.ts
@@ -6,6 +6,7 @@ export interface ApplicationItemProps {
   gender: string;
   stuNum: string;
   listType: string;
+  lastRank: number;
 }
 
 export interface NullApplicationItemProps {

--- a/src/types/List.ts
+++ b/src/types/List.ts
@@ -6,7 +6,7 @@ export interface ApplicationItemProps {
   gender: string;
   stuNum: string;
   listType: string;
-  lastRank: number;
+  lastRank?: number;
 }
 
 export interface NullApplicationItemProps {


### PR DESCRIPTION
## 🔍 개요
자습 신청 인원과 관계없이 무조건 50등만 스탬프 아이콘이 나타남
## 📃 작업사항

신청한 전체 인원을 구해 신청한 인원 중 마지막 사람에게 스탬프 아이콘 표시 (1,2,3등은 제외)
<img width="559" alt="스크린샷 2024-01-23 20 17 46" src="https://github.com/Team-Ampersand/Dotori-client-v2/assets/103751430/f321bf0c-f2b3-44ab-b99a-5728ed8f1abc">

<img width="722" alt="스크린샷 2024-01-23 20 17 52" src="https://github.com/Team-Ampersand/Dotori-client-v2/assets/103751430/7f274dfa-ee86-4fb6-927c-844768fe0cd3">


<img width="905" alt="스크린샷 2024-01-23 20 17 28" src="https://github.com/Team-Ampersand/Dotori-client-v2/assets/103751430/85846f0f-e875-4680-898d-f873bbe8320a">


## 🔀 변경로직
ApplicationItem에 신청한 사람의 전체 인원수를 넘겨 해당하는 마지막 사람에게 스탬프 아이콘이 표시되도록 변경
