### PR TITLE
🔀 프로필 사진 삭제 후처리 및 학생정보 페이지 프로필 이미지 노출

### DIFF
--- a/src/assets/svg/CircleDefaultProfile.tsx
+++ b/src/assets/svg/CircleDefaultProfile.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+const CircleDefaultProfile = () => {
+  return (
+    <svg
+      width="40"
+      height="40"
+      viewBox="0 0 40 40"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g clipPath="url(#clip0_12744_5170)">
+        <rect width="40" height="40" rx="20" fill="#E2E2EE" />
+        <path
+          d="M34.1462 34.6345C34.1462 39.2144 27.8127 42.9272 19.9999 42.9272C12.187 42.9272 5.85352 39.2144 5.85352 34.6345C5.85352 30.0546 12.187 26.3418 19.9999 26.3418C27.8127 26.3418 34.1462 30.0546 34.1462 34.6345Z"
+          fill="#FDFDFD"
+        />
+        <path
+          d="M26.8294 17.5597C26.8294 21.3314 23.7719 24.389 20.0002 24.389C16.2285 24.389 13.1709 21.3314 13.1709 17.5597C13.1709 13.788 16.2285 10.7305 20.0002 10.7305C23.7719 10.7305 26.8294 13.788 26.8294 17.5597Z"
+          fill="#FDFDFD"
+        />
+      </g>
+      <rect
+        x="1"
+        y="1"
+        width="38"
+        height="38"
+        rx="19"
+        stroke="#E2E2EE"
+        strokeWidth="2"
+      />
+      <defs>
+        <clipPath id="clip0_12744_5170">
+          <rect width="40" height="40" rx="20" fill="white" />
+        </clipPath>
+      </defs>
+    </svg>
+  );
+};
+
+export default CircleDefaultProfile;

--- a/src/assets/svg/index.ts
+++ b/src/assets/svg/index.ts
@@ -50,3 +50,4 @@ export { default as EllipsisVerticalIcon } from './EllipsisVerticalIcon';
 export { default as NewPageIcon } from './NewPageIcon';
 export { default as TrashcanIcon } from './TrashcanIcon';
 export { default as SettingIcon } from './SettingIcon';
+export { default as CircleDefaultProfile } from './CircleDefaultProfile';

--- a/src/components/Home/molecules/ProfileImgModal/index.tsx
+++ b/src/components/Home/molecules/ProfileImgModal/index.tsx
@@ -82,6 +82,7 @@ const ProfileImgModal = () => {
 
   const handleRemoveClick = async () => {
     await deleteProfileImage();
+    setImgBase64('')
     setProfileImgModal(false);
     toast.success('프로필 이미지를 삭제했습니다.');
     mutate();

--- a/src/components/Home/organisms/Profile/style.ts
+++ b/src/components/Home/organisms/Profile/style.ts
@@ -41,8 +41,8 @@ export const ProfileBox = styled.div`
 `;
 
 export const ProfileImage = styled.div<{image: string}>`
-  width: 82px;
-  height: 82px;
+  width: 64px;
+  height: 64px;
   border-radius: 8px;
   background-position: center;
   background-image: url(${(props) => props.image});

--- a/src/components/StuInfo/molecules/StuInfoItem/index.tsx
+++ b/src/components/StuInfo/molecules/StuInfoItem/index.tsx
@@ -1,8 +1,13 @@
 import { cancelSelfStudyBan, selfStudyBan } from 'api/selfStudy';
 import { RoleData } from 'assets/data/RoleData';
-import { BookIcon, EditPencilIcon } from 'assets/svg';
+import {
+  BookIcon,
+  CircleDefaultProfile,
+  EditPencilIcon
+} from 'assets/svg';
 import BookBenIcon from 'assets/svg/BookBenIcon';
 import CommonCheckModal from 'components/Common/molecules/CommonCheckModal';
+import EditModal from 'components/StuInfo/organisms/EditModal';
 import { useState } from 'react';
 import { Palette } from 'styles/globals';
 import { mutate } from 'swr';
@@ -10,7 +15,6 @@ import { StuInfoType } from 'types/components/StuInfoPage';
 import { getRole } from 'utils/Libs/getRole';
 import { StuInfoController } from 'utils/Libs/requestUrls';
 import * as S from './style';
-import EditModal from 'components/StuInfo/organisms/EditModal';
 
 interface Props {
   data: StuInfoType;
@@ -63,7 +67,7 @@ const StuInfoItem = ({ data: stuInfoData }: Props) => {
           {stuInfoData.profileImage ? (
             <S.ImgBox image={stuInfoData.profileImage} />
           ) : (
-            <S.ImgBox />
+            <CircleDefaultProfile />
           )}
           <p>{stuInfoData.memberName}</p>
         </S.LeftBox>

--- a/src/components/StuInfo/molecules/StuInfoItem/style.ts
+++ b/src/components/StuInfo/molecules/StuInfoItem/style.ts
@@ -30,7 +30,6 @@ export const ImgBox = styled.div<{ image?: string | null }>`
   height: 40px;
   aspect-ratio: 1 / 1;
   border-radius: 100%;
-  background-color: ${(props) => props.image === null && Palette.NEUTRAL_N40};
 
   ${(props) =>
     props.image &&


### PR DESCRIPTION
## 🔍 개요
프로필 삭제 후 이미지가 남아있었습니다.
자습신청, 마사지 페이지에서만 프로필 이미지가 나타났습니다.
## 📃 작업사항
- 삭제 후 남아있는 사진 삭제
- 자습신청, 안마의자 페이지 프로필 크기 수정
- 학생정보 페이지에 프로필 이미지 노출

