### PR TITLE
:bug: Fix duplication export

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -22,9 +22,8 @@ const nextConfig = {
   },
 };
 
-module.exports = nextConfig;
-
 const withBundleAnalyzer = require('@next/bundle-analyzer')({
   enabled: process.env.ANALYZE === 'true',
 });
-module.exports = withBundleAnalyzer();
+
+module.exports = withBundleAnalyzer(nextConfig);


### PR DESCRIPTION
## 🔍 개요
next.config.js 파일에서 중복으로 모듈을 내보내어 오류가 생겼습니다.
## 📃 작업사항
- module.exports를 1개로 변경
- nextConfig를 withBundleAnalyzer 모듈로 감싸기
