### PR TITLE
🔀 여자일 때는 마사지 신청 불가로 상태 변경

### DIFF
--- a/src/components/Home/organisms/MassageBoard/index.tsx
+++ b/src/components/Home/organisms/MassageBoard/index.tsx
@@ -1,18 +1,18 @@
-import ApplyBox from 'components/Home/molecules/ApplyBox';
-import { applyPageProps, applyStyleProps } from 'types';
-import { Dispatch, SetStateAction, useEffect, useState } from 'react';
-import CommonCheckModal from 'components/Common/molecules/CommonCheckModal';
-import ApplyModifyModal from 'components/Home/molecules/ApplyModifyModal';
 import {
   applyCancelMassage,
   applyMassage,
   applyModifyMassage,
 } from 'api/massage';
-import { getRole } from 'utils/Libs/getRole';
-import useSWR from 'swr';
-import { MassageController } from 'utils/Libs/requestUrls';
+import CommonCheckModal from 'components/Common/molecules/CommonCheckModal';
+import ApplyBox from 'components/Home/molecules/ApplyBox';
+import ApplyModifyModal from 'components/Home/molecules/ApplyModifyModal';
 import UseToggleTheme from 'hooks/useToggleTheme';
+import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { toast } from 'react-toastify';
+import useSWR from 'swr';
+import { applyPageProps, applyStyleProps, myProfileType } from 'types';
+import { getRole } from 'utils/Libs/getRole';
+import { MassageController, MemberController } from 'utils/Libs/requestUrls';
 
 const MassageBoard = () => {
   const [info, setInfo] = useState<applyStyleProps>({
@@ -24,10 +24,12 @@ const MassageBoard = () => {
   const [theme] = UseToggleTheme();
   const { data, mutate } = useSWR<applyPageProps>(
     MassageController.massage(role)
-  );
+    );
+  const { data: myProfile } = useSWR<myProfileType>(MemberController.myProfile);
 
   useEffect(() => {
     if (role === 'admin') return setInfo({ applyStatus: '인원수정' });
+    else if (myProfile?.gender === 'WOMAN') return setInfo({ applyStatus: '신청불가' })
     switch (data?.massageStatus) {
       case 'CAN':
         return setInfo({ applyStatus: '안마의자' });

--- a/src/types/Home.ts
+++ b/src/types/Home.ts
@@ -27,8 +27,8 @@ export interface myProfileType {
   id: number;
   stuNum: string;
   name: string;
-  gender: 'MAN' | 'WOMAN';
-  profileImage: string | null
+  gender: 'MAN' | 'WOMAN' | 'PENDING';
+  profileImage: string | null;
 }
 
 export interface applyPageProps {


### PR DESCRIPTION
## 🔍 개요
여자일때도 마사지 신청이 가능했습니다.
## 📃 작업사항
- MassageBoard 컴포넌트의 useEffect에서 성별을 확인해 info를 신청 불가로 변경했습니다.
