### PR TITLE
🔀 모바일 화면의 음악 삭제 버튼 권한 부여

### DIFF
--- a/src/components/Song/molecules/ResponsiveModal/index.tsx
+++ b/src/components/Song/molecules/ResponsiveModal/index.tsx
@@ -1,8 +1,7 @@
 import { ResponseOverayWrapper } from 'components/Common/atoms/Wrappers/ModalOverayWrapper/style';
 import * as S from './style';
 import { NewPageIcon, TrashcanIcon } from 'assets/svg';
-import { SongResponsiveModalProps, myProfileType } from 'types';
-import { SongType } from 'types/components/SongPage';
+import { SongResponsiveModalProps } from 'types';
 import { preventEvent } from 'utils/Libs/preventEvent';
 import { getRole } from 'utils/Libs/getRole';
 
@@ -12,10 +11,7 @@ const ResponsiveModal = ({
   setDelModalState,
   songData,
   userData,
-}: SongResponsiveModalProps & {
-  songData: SongType;
-  userData: myProfileType;
-}) => {
+}: SongResponsiveModalProps) => {
   const role = getRole();
   return (
     <>

--- a/src/components/Song/molecules/ResponsiveModal/index.tsx
+++ b/src/components/Song/molecules/ResponsiveModal/index.tsx
@@ -1,14 +1,22 @@
 import { ResponseOverayWrapper } from 'components/Common/atoms/Wrappers/ModalOverayWrapper/style';
 import * as S from './style';
 import { NewPageIcon, TrashcanIcon } from 'assets/svg';
-import { SongResponsiveModalProps } from 'types';
+import { SongResponsiveModalProps, myProfileType } from 'types';
+import { SongType } from 'types/components/SongPage';
 import { preventEvent } from 'utils/Libs/preventEvent';
+import { getRole } from 'utils/Libs/getRole';
 
 const ResponsiveModal = ({
   modalState,
   setModalState,
   setDelModalState,
-}: SongResponsiveModalProps) => {
+  songData,
+  userData,
+}: SongResponsiveModalProps & {
+  songData: SongType;
+  userData: myProfileType;
+}) => {
+  const role = getRole();
   return (
     <>
       <S.ModalWrapper modalState={modalState}>
@@ -17,16 +25,19 @@ const ResponsiveModal = ({
             <NewPageIcon />
             바로가기
           </div>
-          <div
-            onClick={(e) => {
-              preventEvent(e);
-              setDelModalState(true);
-              setModalState(false);
-            }}
-          >
-            <TrashcanIcon />
-            기상음악 삭제
-          </div>
+          {(role !== 'member' ||
+            String(songData.stuNum) === userData.stuNum) && (
+            <div
+              onClick={(e) => {
+                preventEvent(e);
+                setDelModalState(true);
+                setModalState(false);
+              }}
+            >
+              <TrashcanIcon />
+              기상음악 삭제
+            </div>
+          )}
         </S.BtnWrapper>
       </S.ModalWrapper>
       <ResponseOverayWrapper

--- a/src/components/Song/molecules/SongItem/index.tsx
+++ b/src/components/Song/molecules/SongItem/index.tsx
@@ -20,7 +20,7 @@ const SongItem = ({ data: songData }: { data: SongType }) => {
   const role = getRole();
   const { data: userData } = useSWR<myProfileType>(MemberController.myProfile);
   const [deleteModal, setDeleteModal] = useState<boolean>(false);
-  const [modalState, setMdoalState] = useState<boolean>(false);
+  const [modalState, setModalState] = useState<boolean>(false);
 
   const createdDate = new Date(songData.createdTime);
   const songDate = `${getDate(createdDate)[3]}시 ${getDate(createdDate)[4]}분`;
@@ -80,7 +80,7 @@ const SongItem = ({ data: songData }: { data: SongType }) => {
           <EllipsisVerticalIcon
             onClick={(e) => {
               preventEvent(e);
-              setMdoalState(true);
+              setModalState(true);
             }}
           />
         </S.ResponsiveBtn>
@@ -91,11 +91,15 @@ const SongItem = ({ data: songData }: { data: SongType }) => {
           setModalState={setDeleteModal}
           onClick={() => onDelete(songData.id)}
         />
-        <ResponsiveModal
-          modalState={modalState}
-          setModalState={setMdoalState}
-          setDelModalState={setDeleteModal}
-        />
+        {userData && (
+          <ResponsiveModal
+            modalState={modalState}
+            setModalState={setModalState}
+            setDelModalState={setDeleteModal}
+            songData={songData}
+            userData={userData}
+          />
+        )}
       </a>
     </Link>
   );

--- a/src/types/Modals.ts
+++ b/src/types/Modals.ts
@@ -1,3 +1,5 @@
+import { SongType } from './components/SongPage';
+import { myProfileType } from './Home';
 export interface MenuOptionStyleProps {
   name: '프로필 수정' | '규정위반 내역' | '비밀번호 변경' | '로그아웃';
 }
@@ -65,4 +67,6 @@ export interface PenaltyRecordModalProps {
 
 export interface SongResponsiveModalProps extends ModalProps {
   setDelModalState: (state: boolean) => void;
+  songData: SongType;
+  userData: myProfileType;
 }


### PR DESCRIPTION
## 🔍 개요
도토리 기상음악 모바일 웹 뷰에서 다른 사람이 신청한 음악의 삭제 버튼이 활성화 되는 문제가 있었습니다.
![image](https://github.com/Team-Ampersand/Dotori-client-v2/assets/129300121/634f4bd3-de77-4b80-b61c-2fd6a1414f8b)


## 📃 작업사항

사용자의 권한이 member이거나 본인이 신청한 음악이 아닐때 삭제 버튼을 감추게 변경 했습니다.

