### PR TITLE
🔀 캘린더의 날짜  버튼 삭제

### DIFF
--- a/src/components/Common/atoms/Calendar/style.ts
+++ b/src/components/Common/atoms/Calendar/style.ts
@@ -54,6 +54,17 @@ export const Layer = styled.div`
     }
   }
 
+  .react-calendar__navigation__prev2-button,
+  .react-calendar__navigation__prev-button,
+  .react-calendar__navigation__next-button,
+  .react-calendar__navigation__next2-button {
+    display: none;
+  }
+
+  .react-calendar__navigation__label {
+    pointer-events: none;
+  }
+
   .react-calendar__month-view__weekdays {
     color: ${Palette.NEUTRAL_N30};
   }


### PR DESCRIPTION
## 🔍 개요

기상음악 신청 관련해서 요금이 매우 많이 나오는 문제가 발생했다. 
이러한 문제를 해결하기 위해 기존에 저장해 뒀던 지난 기상 음악들을 db에서 제거하고 캘린더의 달과 년도를 변경을 비활성화 해야 했다.

## 📃 작업사항

- 캘린더의 화살표 부분 제거
- 년도 변경 버튼 비활성화
