### PR TITLE
🔀 캘린더의 달 변경 불가

### DIFF
--- a/src/components/Common/atoms/Calendar/style.ts
+++ b/src/components/Common/atoms/Calendar/style.ts
@@ -61,6 +61,10 @@ export const Layer = styled.div`
     display: none;
   }
 
+  .react-calendar__tile.react-calendar__month-view__days__day.react-calendar__month-view__days__day--neighboringMonth {
+    pointer-events: none;
+  }
+
   .react-calendar__navigation__label {
     pointer-events: none;
   }


### PR DESCRIPTION
## 🔍 개요

캘린더에서 위의 날짜를 삭제 해도 달이 변경되는 문제가 있었다.

## 📃 작업사항

css 스타일을 변경하여 event를 금지했다.