### PR TITLE
🔀 프로필 이미지 수정,추가 메시지 문제 해결

### DIFF
--- a/src/components/Home/molecules/ProfileImgModal/index.tsx
+++ b/src/components/Home/molecules/ProfileImgModal/index.tsx
@@ -1,7 +1,7 @@
 import {
   deleteProfileImage,
   patchProfileImage,
-  postProfileImage
+  postProfileImage,
 } from 'api/member';
 import { CameraIcon, TrashcanIcon } from 'assets/svg';
 import ModalHeader from 'components/Common/atoms/ModalHeader';
@@ -52,13 +52,15 @@ const ProfileImgModal = () => {
     try {
       const croppedImage = await getCroppedImg(imgBase64, 0, croppedAreaPixels);
       if (data?.profileImage) {
-        await patchProfileImage(croppedImage ?? '');
+        const data = await patchProfileImage(croppedImage ?? '');
         setProfileImgModal(false);
+        if( !data ) return toast.error('프로필 이미지 수정을 실패했습니다');
         toast.success('프로필 이미지를 수정했습니다');
       } else {
-        await postProfileImage(croppedImage ?? '');
+        const data = await postProfileImage(croppedImage ?? '');
         setProfileImgModal(false);
-        toast.success('프로필 이미지를 추가했습니다');
+        if( !data ) return toast.error('프로필 이미지 추가를 실패했습니다');
+        data && toast.success('프로필 이미지를 추가했습니다');
       }
 
       mutate();
@@ -82,7 +84,7 @@ const ProfileImgModal = () => {
 
   const handleRemoveClick = async () => {
     await deleteProfileImage();
-    setImgBase64('')
+    setImgBase64('');
     setProfileImgModal(false);
     toast.success('프로필 이미지를 삭제했습니다.');
     mutate();


### PR DESCRIPTION
## 🔍 개요
프로필 이미지를 수정,추가에 실패했을 때도 성공했다는 메시지가 뜨는 문제가 발생했습니다.
## 📃 작업사항
수정,추가 요청이 성공했을 때의 데이터 유무로 실패와 성공을 구분했습니다.
