### PR TITLE
🔀 토큰 오염시 리프래쉬 문제 해결

### DIFF
--- a/src/components/Common/atoms/Calendar/style.ts
+++ b/src/components/Common/atoms/Calendar/style.ts
@@ -69,6 +69,10 @@ export const Layer = styled.div`
     pointer-events: none;
   }
 
+  .react-calendar__navigation button {
+    margin: 0;
+  }
+
   .react-calendar__month-view__weekdays {
     color: ${Palette.NEUTRAL_N30};
   }

--- a/src/utils/Libs/apiClient.ts
+++ b/src/utils/Libs/apiClient.ts
@@ -1,10 +1,76 @@
 import axios from 'axios';
 import BASE_HEADER from '../Config/Config.json';
 import { getRefresh } from './getRefresh';
+import { getCookie } from './getCookie';
+import { MemberController } from './requestUrls';
+import { setToken } from './setToken';
 
 export const apiClient = axios.create({
   baseURL: process.env.NEXT_PUBLIC_BASE_URL,
   headers: BASE_HEADER,
 });
 
+let isRefreshing = false;
+let failedRequestsQueue: any[] = [];
+
+const onRerefreshToken = (token: string) => {
+  failedRequestsQueue.forEach((callback) => callback(token));
+  failedRequestsQueue = [];
+};
+
+const addFailedRequestToQueue = (callback: (token: string) => void) => {
+  failedRequestsQueue.push(callback);
+};
+
 apiClient.interceptors.request.use(getRefresh);
+
+apiClient.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+    const { response } = error;
+
+    if (response && response.status === 403) {
+      if (!isRefreshing) {
+        isRefreshing = true;
+        const checkRefreshToken = getCookie('RefreshToken');
+
+        try {
+          const { data } = await apiClient.patch(
+            MemberController.auth,
+            {},
+            {
+              headers: {
+                'Refresh-Token': 'Bearer ' + checkRefreshToken,
+              },
+            }
+          );
+          const newAuthorization = data.accessToken;
+          const refreshToken = data.refreshToken;
+          setToken(newAuthorization, refreshToken, null);
+
+          apiClient.defaults.headers[
+            'Authorization'
+          ] = `Bearer ${newAuthorization}`;
+          isRefreshing = false;
+          onRerefreshToken(newAuthorization);
+
+          return apiClient(originalRequest);
+        } catch (e: any) {
+          isRefreshing = false;
+          console.error(e);
+          return Promise.reject(error);
+        }
+      }
+
+      return new Promise((resolve) => {
+        addFailedRequestToQueue((token) => {
+          originalRequest.headers['Authorization'] = `Bearer ${token}`;
+          resolve(apiClient(originalRequest));
+        });
+      });
+    }
+
+    return Promise.reject(error);
+  }
+);

--- a/src/utils/Libs/getCookie.ts
+++ b/src/utils/Libs/getCookie.ts
@@ -1,0 +1,14 @@
+export const getCookie = (name: string): string | null => {
+  const value = `; ${document.cookie}`;
+  const parts = value.split(`; ${name}=`);
+  if (parts.length === 2) {
+    const cookieValue = parts.pop()?.split(';').shift() || null;
+    if (cookieValue) {
+      const decodedValue = decodeURIComponent(cookieValue);
+      return decodedValue.startsWith('Bearer ')
+        ? decodedValue.substring(7)
+        : decodedValue;
+    }
+  }
+  return null;
+};

--- a/src/utils/Libs/getRefresh.ts
+++ b/src/utils/Libs/getRefresh.ts
@@ -1,12 +1,17 @@
 import { AxiosRequestConfig } from 'axios';
 import { tokenReissue } from '../../api/member';
 import { getToken } from './getToken';
+import { MemberController } from './requestUrls';
 
 export const getRefresh = async (config: AxiosRequestConfig) => {
   if (typeof window !== 'object') return config;
   const { Authorization, RefreshToken } = await getToken(null);
 
-  if (config.headers && Authorization) {
+  if (
+    config.headers &&
+    Authorization &&
+    !config.url?.includes(MemberController.auth)
+  ) {
     config.headers['Authorization'] = Authorization;
   } else if (
     !Authorization &&


### PR DESCRIPTION
## 🔍 개요
토큰이 오염된 상태로 요청을 보내면 403 에러가 뜨고 리프래쉬가 진행되지 않던 문제가 있었다.

## 📃 작업사항
- axios interceptors를 사용하여 요청을 가로체 리프래쉬를 진행

## 🔀 변경로직
- apiClient:  axios interceptors를 사용하여 요청을 가로체 리프래쉬
- getCookie: 저장된 쿠키를 파싱하는 로직 추가
- getRefresh: 조건식을 추가하여 refresh 요청시 헤더에 Authorization가 추가가 안되게 설정
- 캘린더의 날짜 마진 제거
