### PR TITLE
🔀: 토큰 만료일 지정 코드 추가

### DIFF
--- a/src/api/member.ts
+++ b/src/api/member.ts
@@ -3,6 +3,7 @@ import { toast } from 'react-toastify';
 import { apiClient } from 'utils/Libs/apiClient';
 import { MemberController } from 'utils/Libs/requestUrls';
 import { setToken } from 'utils/Libs/setToken';
+import { setCookie } from 'nookies';
 
 export const signin = async (id: string, password: string) => {
   try {
@@ -10,7 +11,13 @@ export const signin = async (id: string, password: string) => {
       email: id,
       password: password,
     });
-    setToken(data.accessToken, data.refreshToken, null);
+    setToken(
+      data.accessToken,
+      data.accessExp,
+      data.refreshToken,
+      data.refreshExp,
+      null
+    );
     return toast.success('로그인이 되었습니다.');
   } catch (e: any) {
     if (e.message === 'Request failed with status code 404') {
@@ -142,8 +149,10 @@ export const tokenReissue = async (
       }
     );
     newAuthorization = data.accessToken;
-    refreshToken = data.refreshToken;
-    setToken(newAuthorization, refreshToken, ctx);
+    setCookie(ctx, 'Authorization', `Bearer ${newAuthorization}`, {
+      expires: data.accessExp,
+      path: '/',
+    });
     return { newAuthorization };
   } catch (e: any) {}
 };

--- a/src/utils/Libs/getToken.ts
+++ b/src/utils/Libs/getToken.ts
@@ -8,9 +8,13 @@ export const getToken = async (ctx: GetServerSidePropsContext | null) => {
     let RefreshToken = ctx.req.cookies['RefreshToken'] || '';
 
     if (!RefreshToken) return {};
-    else if (!Authorization) {
-      const { newAuthorization }: any = await tokenReissue(RefreshToken, ctx);
-      Authorization = newAuthorization;
+    if (!Authorization) {
+      try {
+        const response: any = await tokenReissue(RefreshToken, ctx);
+        Authorization = response?.newAuthorization || '';
+      } catch {
+        return {};
+      }
     }
 
     return { Authorization, RefreshToken };

--- a/src/utils/Libs/getToken.ts
+++ b/src/utils/Libs/getToken.ts
@@ -10,7 +10,7 @@ export const getToken = async (ctx: GetServerSidePropsContext | null) => {
     if (!RefreshToken) return {};
     if (!Authorization) {
       try {
-        const response: any = await tokenReissue(RefreshToken, ctx);
+        const response = await tokenReissue(RefreshToken, ctx);
         Authorization = response?.newAuthorization || '';
       } catch {
         return {};

--- a/src/utils/Libs/logout.ts
+++ b/src/utils/Libs/logout.ts
@@ -5,6 +5,5 @@ import { removeToken } from 'utils/Libs/removeToken';
 export const logout = () => {
   removeToken();
   mutate(() => true, undefined, { revalidate: false });
-  removeToken();
   toast.success('로그아웃되었습니다.');
 };

--- a/src/utils/Libs/setToken.ts
+++ b/src/utils/Libs/setToken.ts
@@ -3,15 +3,21 @@ import { setCookie } from 'nookies';
 
 export const setToken = (
   Authorization: string,
+  AuthorizationExp: string,
   RefreshToken: string,
+  RefreshTokenExp: string,
   ctx: GetServerSidePropsContext | null
 ): void => {
+  const authExpires = new Date(AuthorizationExp);
+  const refreshExpires = new Date(RefreshTokenExp);
+
   setCookie(ctx, 'Authorization', `Bearer ${Authorization}`, {
-    maxAge: 10800,
+    expires: authExpires,
     path: '/',
-  }); // 3시간
+  });
+
   setCookie(ctx, 'RefreshToken', `Bearer ${RefreshToken}`, {
-    maxAge: 15768000,
+    expires: refreshExpires,
     path: '/',
-  }); // 6개월
+  });
 };


### PR DESCRIPTION
## 🔍 개요
토큰의 만료일을 서버에서 지정해주는 만료일이 아니라 클라이언트에서 임의로 지정한 값을 사용하고있었습니다.

issue: #274 
## 📃 작업사항
+ setToken()에 만료일 코드 삽입
+ 불필요한 중복코드 제거
## 🔀 변경로직

## 🎸 기타
