### PR TITLE
🔀header에 자동으로 accessToken이 삽입되지 않아 모든 통신에서 401이 뜨는 문제 해결

### DIFF
--- a/src/utils/Libs/apiClient.ts
+++ b/src/utils/Libs/apiClient.ts
@@ -1,8 +1,7 @@
 import axios from 'axios';
 import BASE_HEADER from '../Config/Config.json';
-import { tokenReissue } from 'api/member';
-import { getToken } from './getToken';
 import { setHeader } from './setHeader';
+import { getRefresh } from './getRefresh';
 
 export const apiClient = axios.create({
   baseURL: process.env.NEXT_PUBLIC_BASE_URL,
@@ -11,37 +10,6 @@ export const apiClient = axios.create({
 
 apiClient.interceptors.request.use(setHeader);
 
-apiClient.interceptors.response.use(
-  function (response) {
-    return response;
-  },
-  async function (err) {
-    const originalRequest = err.config;
-
-    if (
-      err.response &&
-      (err.response.status === 401 || err.response.status === 403) &&
-      !originalRequest._retry
-    ) {
-      originalRequest._retry = true;
-
-      try {
-        const { RefreshToken } = await getToken(null);
-        const tokenResponse = await tokenReissue(
-          'Bearer ' + RefreshToken,
-          null
-        );
-
-        if (tokenResponse && tokenResponse.newAuthorization) {
-          originalRequest.headers['Authorization'] =
-            'Bearer ' + tokenResponse.newAuthorization;
-          return apiClient(originalRequest);
-        }
-      } catch (refreshError) {
-        return Promise.reject(refreshError);
-      }
-    }
-
-    return Promise.reject(err);
-  }
-);
+apiClient.interceptors.response.use(function (response) {
+  return response;
+}, getRefresh);

--- a/src/utils/Libs/apiClient.ts
+++ b/src/utils/Libs/apiClient.ts
@@ -2,11 +2,14 @@ import axios from 'axios';
 import BASE_HEADER from '../Config/Config.json';
 import { tokenReissue } from 'api/member';
 import { getToken } from './getToken';
+import { setHeader } from './setHeader';
 
 export const apiClient = axios.create({
   baseURL: process.env.NEXT_PUBLIC_BASE_URL,
   headers: BASE_HEADER,
 });
+
+apiClient.interceptors.request.use(setHeader);
 
 apiClient.interceptors.response.use(
   function (response) {

--- a/src/utils/Libs/getRefresh.ts
+++ b/src/utils/Libs/getRefresh.ts
@@ -1,0 +1,45 @@
+import { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios';
+import { getToken } from './getToken';
+import { tokenReissue } from 'api/member';
+import { apiClient } from './apiClient';
+
+interface TokenResponse {
+  newAuthorization: string;
+}
+
+export async function getRefresh(
+  err: AxiosError
+): Promise<AxiosResponse | Promise<never>> {
+  const originalRequest = err.config as AxiosRequestConfig & {
+    _retry?: boolean;
+  };
+
+  if (
+    err.response &&
+    (err.response.status === 401 || err.response.status === 403) &&
+    !originalRequest._retry
+  ) {
+    originalRequest._retry = true;
+
+    try {
+      const { RefreshToken } = (await getToken(null)) as {
+        RefreshToken: string;
+      };
+      const tokenResponse = (await tokenReissue(
+        'Bearer ' + RefreshToken,
+        null
+      )) as TokenResponse;
+
+      if (tokenResponse && tokenResponse.newAuthorization) {
+        originalRequest.headers = originalRequest.headers || {};
+        originalRequest.headers['Authorization'] =
+          'Bearer ' + tokenResponse.newAuthorization;
+        return apiClient(originalRequest);
+      }
+    } catch (refreshError) {
+      return Promise.reject(refreshError);
+    }
+  }
+
+  return Promise.reject(err);
+}

--- a/src/utils/Libs/setHeader.ts
+++ b/src/utils/Libs/setHeader.ts
@@ -1,0 +1,18 @@
+import { AxiosRequestConfig } from 'axios';
+import { getToken } from './getToken';
+import { MemberController } from './requestUrls';
+
+export const setHeader = async (config: AxiosRequestConfig) => {
+  if (typeof window !== 'object') return config;
+  const { Authorization } = await getToken(null);
+
+  if (
+    config.headers &&
+    Authorization &&
+    !config.url?.includes(MemberController.auth)
+  ) {
+    config.headers['Authorization'] = Authorization;
+  }
+
+  return config;
+};


### PR DESCRIPTION
## 🔍 개요
header에 자동으로 accessToken이 삽입되지 않아 모든 통신에서 401이 떠 자동으로 refresh가 진행되어 200에러가 뜨는 문제가 있었다.
## 📃 작업사항
interceptors.request.use로 통신을 가로체 자동으로 accessToken이 header에 삽입되게 변경
