### PR TITLE
🔀 안마의자 페이지 메시지 추가

### DIFF
--- a/src/components/Massage/organisms/MassageTable/index.tsx
+++ b/src/components/Massage/organisms/MassageTable/index.tsx
@@ -20,7 +20,11 @@ const MassageTable = () => {
           <MassageList />
         </S.ListWrapper>
       ) : (
-        <NullApplicstionItem Icon={CupIcon} message="" subMessage="" />
+        <NullApplicstionItem 
+          Icon={CupIcon} 
+          message="안마의자를 신청한 인원이 없습니다.." 
+          subMessage="홈에서 안마의자 신청을 해보세요!" 
+        />
       )}
     </S.TableWrapper>
   );


### PR DESCRIPTION
## 🔍 개요
안마의자 페이지에 메시지가 사라져있었습니다
## 📃 작업사항
- 안마의자 페이지 메시지 추가

![image](https://github.com/user-attachments/assets/56e91ef7-05d6-45cb-ab55-ddc5097eb484)

![image](https://github.com/user-attachments/assets/c78f0c96-dee1-491f-ae3a-c4bcaf72e620)
