### PR TITLE
🔀 리프레시 시  캘린더 날짜가 14일로 나오는 오류

### DIFF
--- a/src/components/Common/atoms/Calendar/index.tsx
+++ b/src/components/Common/atoms/Calendar/index.tsx
@@ -25,7 +25,12 @@ const CalendarBox = ({
       )}
       <Calendar
         value={selectedDate}
+        activeStartDate={selectedDate}
         onChange={(value) => {
+          if (!(value instanceof Date)) return;
+          setSelectedDate?.(value);
+        }}
+        onActiveStartDateChange={({value}) => {
           if (!(value instanceof Date)) return;
           setSelectedDate?.(value);
         }}


### PR DESCRIPTION
## 🔍 개요
리프레시 시 날짜가 오늘의 날짜가 아닌 14일로 고정되어 나오는 오류가 있었습니다.
## 📃 작업사항
- calendar에 activeStartDate 추가
## 🎸 기타
- 로컬에서는 오류가 발생하지 않아 제대로 작동하는지 확인하지 못했습니다..